### PR TITLE
Add DST script for European timezones

### DIFF
--- a/europe_dst.py
+++ b/europe_dst.py
@@ -1,0 +1,40 @@
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+import sys
+
+
+def get_next_dst_transition(tz_name: str) -> datetime | None:
+    """Return the next DST transition time for the given timezone."""
+    tz = ZoneInfo(tz_name)
+    now = datetime.now(tz)
+    current_offset = now.utcoffset()
+    # check up to one year ahead for a transition
+    for day_offset in range(1, 366):
+        candidate = now + timedelta(days=day_offset)
+        if candidate.utcoffset() != current_offset:
+            return candidate
+    return None
+
+
+def main() -> None:
+    tz_name = sys.argv[1] if len(sys.argv) > 1 else "Europe/Athens"
+    try:
+        tz = ZoneInfo(tz_name)
+    except Exception as exc:
+        sys.exit(f"Unknown timezone {tz_name}: {exc}")
+
+    now = datetime.now(tz)
+    print(f"Current time in {tz_name}: {now:%Y-%m-%d %H:%M:%S %Z%z}")
+
+    next_transition = get_next_dst_transition(tz_name)
+    if next_transition:
+        print(
+            "Next DST transition occurs on"
+            f" {next_transition:%Y-%m-%d %H:%M:%S %Z%z}"
+        )
+    else:
+        print("No DST transition found in the next year.")
+
+
+if __name__ == "__main__":
+    main()

--- a/greece_dst.py
+++ b/greece_dst.py
@@ -1,0 +1,30 @@
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+
+def next_dst_change(tz_name: str = "Europe/Athens") -> datetime | None:
+    """Return the exact datetime of the next DST change for Greece."""
+    tz = ZoneInfo(tz_name)
+    now = datetime.now(tz).replace(minute=0, second=0, microsecond=0)
+    initial_offset = now.utcoffset()
+    # search for a change within the next year using hourly increments
+    limit = now + timedelta(days=366)
+    while now < limit:
+        now += timedelta(hours=1)
+        if now.utcoffset() != initial_offset:
+            return now
+    return None
+
+
+if __name__ == "__main__":
+    timezone = "Europe/Athens"
+    now = datetime.now(ZoneInfo(timezone))
+    print(f"Τρέχουσα ώρα στην Ελλάδα: {now:%Y-%m-%d %H:%M:%S %Z%z}")
+    change = next_dst_change(timezone)
+    if change:
+        print(
+            "Η επόμενη αλλαγή ώρας είναι στις",
+            f"{change:%Y-%m-%d %H:%M:%S %Z%z}",
+        )
+    else:
+        print("Δε βρέθηκε αλλαγή ώρας μέσα στον επόμενο χρόνο.")


### PR DESCRIPTION
## Summary
- add `europe_dst.py` for displaying current time and next daylight saving time transition

## Testing
- `python3 europe_dst.py`
- `python3 europe_dst.py Europe/London`


------
https://chatgpt.com/codex/tasks/task_e_68457347fe64832e9bf9811cedc8039b