### PR TITLE
Improve DST listing

### DIFF
--- a/europe_dst.py
+++ b/europe_dst.py
@@ -1,0 +1,108 @@
+"""Display daylight saving time transitions for a European timezone.
+
+This script prints the current time in the chosen zone (``Europe/Athens`` by
+default) and lists all DST changes that will occur within a configurable
+time range (one year by default). Each change is reported with the exact
+timestamp and whether daylight saving time starts or ends.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+import argparse
+import sys
+
+
+def find_dst_transitions(
+    tz_name: str,
+    start: datetime,
+    days: int = 365,
+) -> list[datetime]:
+    """Return all DST transition datetimes within ``days`` days."""
+
+    tz = ZoneInfo(tz_name)
+    current = start.astimezone(tz)
+    end = current + timedelta(days=days)
+    step = timedelta(days=1)
+    offset = current.utcoffset() or timedelta()
+    transitions: list[datetime] = []
+
+    while current < end:
+        nxt = min(current + step, end)
+        if (nxt.utcoffset() or timedelta()) != offset:
+            # Narrow down the exact change moment to one second precision
+            low, high = current, nxt
+            while high - low > timedelta(seconds=1):
+                mid = low + (high - low) / 2
+                if mid.utcoffset() == offset:
+                    low = mid
+                else:
+                    high = mid
+            transitions.append(high)
+            offset = high.utcoffset() or timedelta()
+            current = high
+            continue
+        current = nxt
+
+    return transitions
+
+
+def parse_args() -> argparse.Namespace:
+    """Return parsed command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="List upcoming daylight saving time changes for a timezone"
+    )
+    parser.add_argument(
+        "zone",
+        nargs="?",
+        default="Europe/Athens",
+        help="Timezone name, e.g. Europe/London",
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=365,
+        help="How many days ahead to search",
+    )
+    parser.add_argument(
+        "--start",
+        help="ISO timestamp to begin searching from",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    tz_name = args.zone
+    try:
+        tz = ZoneInfo(tz_name)
+    except ZoneInfoNotFoundError as exc:
+        sys.exit(f"Unknown timezone {tz_name}: {exc}")
+
+    if args.start:
+        try:
+            start = datetime.fromisoformat(args.start)
+        except ValueError as exc:
+            sys.exit(f"Invalid --start value: {exc}")
+        start = start.replace(tzinfo=tz) if start.tzinfo is None else start.astimezone(tz)
+    else:
+        start = datetime.now(tz)
+    print(f"Current time in {tz_name}: {start:%Y-%m-%d %H:%M:%S %Z%z}")
+
+    transitions = find_dst_transitions(tz_name, start, days=args.days)
+    if transitions:
+        print("Upcoming DST changes:")
+        for trans in transitions:
+            prev_offset = (trans - timedelta(minutes=1)).astimezone(
+                tz
+            ).utcoffset() or timedelta()
+            new_offset = trans.utcoffset() or timedelta()
+            action = "starts" if new_offset > prev_offset else "ends"
+            print(f"  {trans:%Y-%m-%d %H:%M:%S %Z%z} - DST {action}")
+    else:
+        print(f"No DST change found in the next {args.days} days.")
+
+
+if __name__ == "__main__":
+    main()

--- a/europe_dst.py
+++ b/europe_dst.py
@@ -1,43 +1,73 @@
-"""Display daylight saving time transitions for a European timezone.
+"""Display daylight saving time transitions for European timezones.
 
-This script prints the current time in the chosen zone (``Europe/Athens`` by
-default) and lists all DST changes that will occur within a configurable
-time range (one year by default). The search can also be bounded by a specific
-end timestamp via ``--until``. Each change is reported with the exact
-timestamp and whether daylight saving time starts or ends.
+The script focuses on the default ``Europe/Athens`` zone but it can report
+transitions for any European timezone supported by :mod:`zoneinfo`. It prints
+the current local time in the selected zone and lists every daylight saving
+change that will occur within the chosen interval (one year by default).
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 import argparse
 import sys
+import datetime as dt
+from dataclasses import dataclass
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 
-def find_dst_transitions(tz_name: str, start: datetime, end: datetime) -> list[datetime]:
-    """Return all DST transition datetimes between ``start`` and ``end``."""
+@dataclass
+class Transition:
+    """Container describing a daylight saving time change."""
+
+    moment: dt.datetime
+    previous_offset: dt.timedelta
+    new_offset: dt.timedelta
+
+    @property
+    def action(self) -> str:
+        """Return ``"starts"`` if DST begins, otherwise ``"ends"``."""
+
+        return "starts" if self.new_offset > self.previous_offset else "ends"
+
+
+def _narrow_transition(
+    tz: ZoneInfo,
+    low: dt.datetime,
+    high: dt.datetime,
+    old_offset: dt.timedelta,
+) -> Transition:
+    """Binary search to pinpoint the DST change moment."""
+
+    precision = dt.timedelta(seconds=1)
+    while high - low > precision:
+        mid = low + (high - low) / 2
+        if (mid.utcoffset() or dt.timedelta()) == old_offset:
+            low = mid
+        else:
+            high = mid
+
+    new_offset = high.utcoffset() or dt.timedelta()
+    return Transition(moment=high, previous_offset=old_offset, new_offset=new_offset)
+
+
+def find_dst_transitions(
+    tz_name: str, start: dt.datetime, end: dt.datetime
+) -> list[Transition]:
+    """Return all DST transitions between ``start`` and ``end``."""
 
     tz = ZoneInfo(tz_name)
     current = start.astimezone(tz)
-    step = timedelta(days=1)
-    offset = current.utcoffset() or timedelta()
-    transitions: list[datetime] = []
+    step = dt.timedelta(days=1)
+    offset = current.utcoffset() or dt.timedelta()
+    transitions: list[Transition] = []
 
     while current < end:
         nxt = min(current + step, end)
-        if (nxt.utcoffset() or timedelta()) != offset:
-            # Narrow down the exact change moment to one second precision
-            low, high = current, nxt
-            while high - low > timedelta(seconds=1):
-                mid = low + (high - low) / 2
-                if mid.utcoffset() == offset:
-                    low = mid
-                else:
-                    high = mid
-            transitions.append(high)
-            offset = high.utcoffset() or timedelta()
-            current = high
+        if (nxt.utcoffset() or dt.timedelta()) != offset:
+            transition = _narrow_transition(tz, current, nxt, offset)
+            transitions.append(transition)
+            offset = transition.new_offset
+            current = transition.moment
             continue
         current = nxt
 
@@ -82,23 +112,23 @@ def main() -> None:
 
     if args.start:
         try:
-            start = datetime.fromisoformat(args.start)
+            start = dt.datetime.fromisoformat(args.start)
         except ValueError as exc:
             sys.exit(f"Invalid --start value: {exc}")
         start = start.replace(tzinfo=tz) if start.tzinfo is None else start.astimezone(tz)
     else:
-        start = datetime.now(tz)
+        start = dt.datetime.now(tz)
 
     if args.until:
         try:
-            end = datetime.fromisoformat(args.until)
+            end = dt.datetime.fromisoformat(args.until)
         except ValueError as exc:
             sys.exit(f"Invalid --until value: {exc}")
         end = end.replace(tzinfo=tz) if end.tzinfo is None else end.astimezone(tz)
     else:
         if args.days < 0:
             sys.exit("--days must be non-negative")
-        end = start + timedelta(days=args.days)
+        end = start + dt.timedelta(days=args.days)
 
     if end <= start:
         sys.exit("--until must be after --start")
@@ -108,11 +138,11 @@ def main() -> None:
     transitions = find_dst_transitions(tz_name, start, end)
     if transitions:
         print("Upcoming DST changes:")
-        for trans in transitions:
-            prev_offset = (trans - timedelta(minutes=1)).astimezone(tz).utcoffset() or timedelta()
-            new_offset = trans.utcoffset() or timedelta()
-            action = "starts" if new_offset > prev_offset else "ends"
-            print(f"  {trans:%Y-%m-%d %H:%M:%S %Z%z} - DST {action}")
+        for transition in transitions:
+            moment = transition.moment
+            print(
+                f"  {moment:%Y-%m-%d %H:%M:%S %Z%z} - DST {transition.action}"
+            )
     else:
         span = (end - start).days
         print(f"No DST change found in the next {span} days.")

--- a/europe_dst.py
+++ b/europe_dst.py
@@ -2,7 +2,8 @@
 
 This script prints the current time in the chosen zone (``Europe/Athens`` by
 default) and lists all DST changes that will occur within a configurable
-time range (one year by default). Each change is reported with the exact
+time range (one year by default). The search can also be bounded by a specific
+end timestamp via ``--until``. Each change is reported with the exact
 timestamp and whether daylight saving time starts or ends.
 """
 
@@ -14,16 +15,11 @@ import argparse
 import sys
 
 
-def find_dst_transitions(
-    tz_name: str,
-    start: datetime,
-    days: int = 365,
-) -> list[datetime]:
-    """Return all DST transition datetimes within ``days`` days."""
+def find_dst_transitions(tz_name: str, start: datetime, end: datetime) -> list[datetime]:
+    """Return all DST transition datetimes between ``start`` and ``end``."""
 
     tz = ZoneInfo(tz_name)
     current = start.astimezone(tz)
-    end = current + timedelta(days=days)
     step = timedelta(days=1)
     offset = current.utcoffset() or timedelta()
     transitions: list[datetime] = []
@@ -66,6 +62,10 @@ def parse_args() -> argparse.Namespace:
         help="How many days ahead to search",
     )
     parser.add_argument(
+        "--until",
+        help="ISO timestamp to stop searching (overrides --days)",
+    )
+    parser.add_argument(
         "--start",
         help="ISO timestamp to begin searching from",
     )
@@ -88,20 +88,34 @@ def main() -> None:
         start = start.replace(tzinfo=tz) if start.tzinfo is None else start.astimezone(tz)
     else:
         start = datetime.now(tz)
+
+    if args.until:
+        try:
+            end = datetime.fromisoformat(args.until)
+        except ValueError as exc:
+            sys.exit(f"Invalid --until value: {exc}")
+        end = end.replace(tzinfo=tz) if end.tzinfo is None else end.astimezone(tz)
+    else:
+        if args.days < 0:
+            sys.exit("--days must be non-negative")
+        end = start + timedelta(days=args.days)
+
+    if end <= start:
+        sys.exit("--until must be after --start")
+
     print(f"Current time in {tz_name}: {start:%Y-%m-%d %H:%M:%S %Z%z}")
 
-    transitions = find_dst_transitions(tz_name, start, days=args.days)
+    transitions = find_dst_transitions(tz_name, start, end)
     if transitions:
         print("Upcoming DST changes:")
         for trans in transitions:
-            prev_offset = (trans - timedelta(minutes=1)).astimezone(
-                tz
-            ).utcoffset() or timedelta()
+            prev_offset = (trans - timedelta(minutes=1)).astimezone(tz).utcoffset() or timedelta()
             new_offset = trans.utcoffset() or timedelta()
             action = "starts" if new_offset > prev_offset else "ends"
             print(f"  {trans:%Y-%m-%d %H:%M:%S %Z%z} - DST {action}")
     else:
-        print(f"No DST change found in the next {args.days} days.")
+        span = (end - start).days
+        print(f"No DST change found in the next {span} days.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- handle naive `--start` timestamps by interpreting them in the chosen timezone
- provide clearer error when an unknown timezone is supplied

## Testing
- `python3 europe_dst.py`
- `python3 europe_dst.py Europe/London`
- `python3 europe_dst.py Europe/London --start 2025-06-01T12:00`


------
https://chatgpt.com/codex/tasks/task_e_68457347fe64832e9bf9811cedc8039b