### PR TITLE
Improve storage path resolution for expense tracker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Build output directories
+**/bin/
+**/obj/
+
+# Visual Studio working files
+.vs/
+
+# User generated data created by the expense tracker
+CSharpApp/data/expenses.json

--- a/CSharpApp/CSharpApp.csproj
+++ b/CSharpApp/CSharpApp.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/CSharpApp/Models/BudgetSummary.cs
+++ b/CSharpApp/Models/BudgetSummary.cs
@@ -1,0 +1,51 @@
+namespace CSharpApp.Models;
+
+/// <summary>
+/// Provides a high level overview of the stored expense information.
+/// </summary>
+public sealed class BudgetSummary
+{
+    public BudgetSummary(
+        decimal totalSpent,
+        decimal averageExpense,
+        Expense? largestExpense,
+        IReadOnlyList<CategoryTotal> categoryTotals,
+        int expenseCount)
+    {
+        if (categoryTotals is null)
+        {
+            throw new ArgumentNullException(nameof(categoryTotals));
+        }
+
+        TotalSpent = totalSpent;
+        AverageExpense = averageExpense;
+        LargestExpense = largestExpense;
+        CategoryTotals = categoryTotals;
+        ExpenseCount = expenseCount;
+    }
+
+    /// <summary>
+    /// Gets the total amount spent for the selected time frame.
+    /// </summary>
+    public decimal TotalSpent { get; }
+
+    /// <summary>
+    /// Gets the average amount of the expenses that form the summary.
+    /// </summary>
+    public decimal AverageExpense { get; }
+
+    /// <summary>
+    /// Gets the largest expense contributing to the summary, if any.
+    /// </summary>
+    public Expense? LargestExpense { get; }
+
+    /// <summary>
+    /// Gets the ordered collection of category totals.
+    /// </summary>
+    public IReadOnlyList<CategoryTotal> CategoryTotals { get; }
+
+    /// <summary>
+    /// Gets the number of expense entries considered while building the summary.
+    /// </summary>
+    public int ExpenseCount { get; }
+}

--- a/CSharpApp/Models/CategoryTotal.cs
+++ b/CSharpApp/Models/CategoryTotal.cs
@@ -1,0 +1,6 @@
+namespace CSharpApp.Models;
+
+/// <summary>
+/// Represents the aggregated amount spent within a specific expense category.
+/// </summary>
+public sealed record CategoryTotal(string Category, decimal Amount);

--- a/CSharpApp/Models/Expense.cs
+++ b/CSharpApp/Models/Expense.cs
@@ -1,0 +1,52 @@
+namespace CSharpApp.Models;
+
+/// <summary>
+/// Represents a single expense entry recorded by the application.
+/// </summary>
+public sealed class Expense
+{
+    /// <summary>
+    /// Gets or sets the unique identifier for the expense entry.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the date on which the expense occurred.
+    /// </summary>
+    public DateTime Date { get; set; }
+
+    /// <summary>
+    /// Gets or sets the category assigned to the expense.
+    /// </summary>
+    public string Category { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets an optional free-text description for the expense.
+    /// </summary>
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the monetary amount of the expense.
+    /// </summary>
+    public decimal Amount { get; set; }
+
+    /// <summary>
+    /// Creates a deep copy of the current <see cref="Expense"/> instance.
+    /// </summary>
+    public Expense Clone()
+    {
+        return new Expense
+        {
+            Id = Id,
+            Date = Date,
+            Category = Category,
+            Description = Description,
+            Amount = Amount
+        };
+    }
+
+    public override string ToString()
+    {
+        return $"{Date:yyyy-MM-dd} | {Category} | {Amount:F2}";
+    }
+}

--- a/CSharpApp/Program.cs
+++ b/CSharpApp/Program.cs
@@ -67,6 +67,8 @@ internal static class Program
 
     private static void HandleAdd(ExpenseService service, CommandLineInput input)
     {
+        EnsureAllowedOptions(input, "date", "category", "amount", "description");
+
         var date = GetRequiredDate(input, "date");
         var category = GetRequiredString(input, "category");
         var amount = GetRequiredDecimal(input, "amount");
@@ -87,6 +89,8 @@ internal static class Program
 
     private static void HandleList(ExpenseService service, CommandLineInput input)
     {
+        EnsureAllowedOptions(input, "from", "to", "category");
+
         var from = GetOptionalDate(input, "from");
         var to = GetOptionalDate(input, "to");
         var categories = GetOptionalCategories(input);
@@ -118,6 +122,8 @@ internal static class Program
 
     private static void HandleSummary(ExpenseService service, CommandLineInput input)
     {
+        EnsureAllowedOptions(input, "from", "to", "category");
+
         var from = GetOptionalDate(input, "from");
         var to = GetOptionalDate(input, "to");
         var categories = GetOptionalCategories(input);
@@ -171,6 +177,8 @@ internal static class Program
 
     private static void HandleRemove(ExpenseService service, CommandLineInput input)
     {
+        EnsureAllowedOptions(input, "id");
+
         var id = GetRequiredGuid(input, "id");
         var removed = service.RemoveExpense(id);
         if (removed)
@@ -312,6 +320,23 @@ internal static class Program
         }
 
         return id;
+    }
+
+    private static void EnsureAllowedOptions(CommandLineInput input, params string[] allowedOptions)
+    {
+        var allowed = new HashSet<string>(allowedOptions, StringComparer.OrdinalIgnoreCase);
+        var unexpected = input.Options.Keys
+            .Where(key => !allowed.Contains(key))
+            .OrderBy(key => key, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (unexpected.Count == 0)
+        {
+            return;
+        }
+
+        throw new ArgumentException(
+            $"Unsupported option(s) for '{input.Command}': {string.Join(", ", unexpected.Select(key => $"--{key}"))}.");
     }
 
     private static IReadOnlyCollection<string>? GetOptionalCategories(CommandLineInput input)

--- a/CSharpApp/Program.cs
+++ b/CSharpApp/Program.cs
@@ -1,0 +1,351 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using CSharpApp.Services;
+using CSharpApp.Utilities;
+
+namespace CSharpApp;
+
+internal static class Program
+{
+    private const string DateFormat = "yyyy-MM-dd";
+    private const string ExecutionHint = "dotnet run --project CSharpApp --";
+
+    private static void Main(string[] args)
+    {
+        if (args.Length == 0 || IsHelpRequest(args[0]))
+        {
+            PrintHelp();
+            return;
+        }
+
+        var storagePath = ResolveStoragePath();
+        var repository = new ExpenseRepository(storagePath);
+        var service = new ExpenseService(repository);
+
+        try
+        {
+            var commandInput = CommandLineParser.Parse(args);
+            switch (commandInput.Command.ToLowerInvariant())
+            {
+                case "add":
+                    HandleAdd(service, commandInput);
+                    break;
+                case "list":
+                    HandleList(service, commandInput);
+                    break;
+                case "summary":
+                    HandleSummary(service, commandInput);
+                    break;
+                case "remove":
+                    HandleRemove(service, commandInput);
+                    break;
+                case "help":
+                    PrintHelp();
+                    break;
+                default:
+                    Console.Error.WriteLine($"Unknown command '{commandInput.Command}'.");
+                    Console.Error.WriteLine();
+                    PrintHelp();
+                    Environment.ExitCode = 1;
+                    break;
+            }
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException or FormatException)
+        {
+            Console.Error.WriteLine($"Error: {ex.Message}");
+            Environment.ExitCode = 1;
+        }
+    }
+
+    private static bool IsHelpRequest(string value)
+    {
+        return string.Equals(value, "-h", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(value, "--help", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(value, "help", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void HandleAdd(ExpenseService service, CommandLineInput input)
+    {
+        var date = GetRequiredDate(input, "date");
+        var category = GetRequiredString(input, "category");
+        var amount = GetRequiredDecimal(input, "amount");
+        var description = GetOptionalString(input, "description") ?? string.Empty;
+
+        var expense = service.AddExpense(date, category, description, amount);
+
+        Console.WriteLine("Expense recorded successfully:");
+        Console.WriteLine($"  Id          : {expense.Id}");
+        Console.WriteLine($"  Date        : {expense.Date.ToString(DateFormat, CultureInfo.InvariantCulture)}");
+        Console.WriteLine($"  Category    : {expense.Category}");
+        Console.WriteLine($"  Amount      : {expense.Amount.ToString("F2", CultureInfo.InvariantCulture)}");
+        if (!string.IsNullOrWhiteSpace(expense.Description))
+        {
+            Console.WriteLine($"  Description : {expense.Description}");
+        }
+    }
+
+    private static void HandleList(ExpenseService service, CommandLineInput input)
+    {
+        var from = GetOptionalDate(input, "from");
+        var to = GetOptionalDate(input, "to");
+        var categories = GetOptionalCategories(input);
+
+        var expenses = service.ListExpenses(from, to, categories);
+        if (expenses.Count == 0)
+        {
+            Console.WriteLine("No expenses found for the specified filters.");
+            return;
+        }
+
+        var rows = new List<IReadOnlyList<string>>
+        {
+            TableFormatter.Row("Id", "Date", "Category", "Amount", "Description")
+        };
+
+        foreach (var expense in expenses)
+        {
+            rows.Add(TableFormatter.Row(
+                expense.Id.ToString(),
+                expense.Date.ToString(DateFormat, CultureInfo.InvariantCulture),
+                expense.Category,
+                expense.Amount.ToString("F2", CultureInfo.InvariantCulture),
+                string.IsNullOrWhiteSpace(expense.Description) ? "-" : expense.Description));
+        }
+
+        Console.WriteLine(TableFormatter.Format(rows));
+    }
+
+    private static void HandleSummary(ExpenseService service, CommandLineInput input)
+    {
+        var from = GetOptionalDate(input, "from");
+        var to = GetOptionalDate(input, "to");
+        var categories = GetOptionalCategories(input);
+
+        var summary = service.GetSummary(from, to, categories);
+        if (summary.ExpenseCount == 0)
+        {
+            Console.WriteLine("No expenses found for the specified filters.");
+            return;
+        }
+
+        Console.WriteLine("Summary");
+        Console.WriteLine("-------");
+        Console.WriteLine($"Entries        : {summary.ExpenseCount}");
+        Console.WriteLine($"Total spent    : {summary.TotalSpent.ToString("F2", CultureInfo.InvariantCulture)}");
+        Console.WriteLine($"Average amount : {summary.AverageExpense.ToString("F2", CultureInfo.InvariantCulture)}");
+
+        if (summary.LargestExpense is { } largest)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Largest expense");
+            Console.WriteLine($"  Id       : {largest.Id}");
+            Console.WriteLine($"  Date     : {largest.Date.ToString(DateFormat, CultureInfo.InvariantCulture)}");
+            Console.WriteLine($"  Category : {largest.Category}");
+            Console.WriteLine($"  Amount   : {largest.Amount.ToString("F2", CultureInfo.InvariantCulture)}");
+            if (!string.IsNullOrWhiteSpace(largest.Description))
+            {
+                Console.WriteLine($"  Notes    : {largest.Description}");
+            }
+        }
+
+        if (summary.CategoryTotals.Count > 0)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Totals by category");
+            var rows = new List<IReadOnlyList<string>>
+            {
+                TableFormatter.Row("Category", "Total")
+            };
+
+            foreach (var categoryTotal in summary.CategoryTotals)
+            {
+                rows.Add(TableFormatter.Row(
+                    categoryTotal.Category,
+                    categoryTotal.Amount.ToString("F2", CultureInfo.InvariantCulture)));
+            }
+
+            Console.WriteLine(TableFormatter.Format(rows));
+        }
+    }
+
+    private static void HandleRemove(ExpenseService service, CommandLineInput input)
+    {
+        var id = GetRequiredGuid(input, "id");
+        var removed = service.RemoveExpense(id);
+        if (removed)
+        {
+            Console.WriteLine("Expense removed successfully.");
+        }
+        else
+        {
+            Console.WriteLine("No expense was found with the provided identifier.");
+            Environment.ExitCode = 1;
+        }
+    }
+
+    private static string ResolveStoragePath()
+    {
+        var overridePath = Environment.GetEnvironmentVariable("EXPENSE_TRACKER_STORAGE");
+        if (!string.IsNullOrWhiteSpace(overridePath))
+        {
+            return Path.GetFullPath(overridePath);
+        }
+
+        var baseDirectory = AppContext.BaseDirectory;
+        var projectRoot = TryResolveProjectRoot(baseDirectory);
+        var dataDirectory = projectRoot is not null
+            ? Path.Combine(projectRoot, "data")
+            : Path.Combine(baseDirectory, "data");
+
+        return Path.Combine(dataDirectory, "expenses.json");
+    }
+
+    private static string? TryResolveProjectRoot(string startDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(startDirectory))
+        {
+            return null;
+        }
+
+        var current = new DirectoryInfo(startDirectory);
+        while (current is not null)
+        {
+            var projectFile = Path.Combine(current.FullName, "CSharpApp.csproj");
+            if (File.Exists(projectFile))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        return null;
+    }
+
+    private static DateTime GetRequiredDate(CommandLineInput input, string name)
+    {
+        if (!input.Options.TryGetValue(name, out var raw))
+        {
+            throw new ArgumentException($"The option '--{name}' is required for the '{input.Command}' command.");
+        }
+
+        return ParseDate(raw, name);
+    }
+
+    private static DateTime? GetOptionalDate(CommandLineInput input, string name)
+    {
+        if (!input.Options.TryGetValue(name, out var raw)
+            || string.IsNullOrWhiteSpace(raw)
+            || string.Equals(raw, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return ParseDate(raw, name);
+    }
+
+    private static DateTime ParseDate(string value, string name)
+    {
+        if (!DateTime.TryParseExact(value, DateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
+        {
+            throw new FormatException($"The value '{value}' is not a valid date for the '--{name}' option. Use the format {DateFormat}.");
+        }
+
+        return date.Date;
+    }
+
+    private static decimal GetRequiredDecimal(CommandLineInput input, string name)
+    {
+        if (!input.Options.TryGetValue(name, out var raw))
+        {
+            throw new ArgumentException($"The option '--{name}' is required for the '{input.Command}' command.");
+        }
+
+        if (!decimal.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var value))
+        {
+            throw new FormatException($"The value '{raw}' is not a valid number for the '--{name}' option.");
+        }
+
+        return value;
+    }
+
+    private static string GetRequiredString(CommandLineInput input, string name)
+    {
+        if (!input.Options.TryGetValue(name, out var raw)
+            || string.IsNullOrWhiteSpace(raw)
+            || string.Equals(raw, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException($"The option '--{name}' is required for the '{input.Command}' command.");
+        }
+
+        return raw.Trim();
+    }
+
+    private static string? GetOptionalString(CommandLineInput input, string name)
+    {
+        if (!input.Options.TryGetValue(name, out var raw)
+            || string.IsNullOrWhiteSpace(raw)
+            || string.Equals(raw, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        return raw.Trim();
+    }
+
+    private static Guid GetRequiredGuid(CommandLineInput input, string name)
+    {
+        if (!input.Options.TryGetValue(name, out var raw))
+        {
+            throw new ArgumentException($"The option '--{name}' is required for the '{input.Command}' command.");
+        }
+
+        if (!Guid.TryParse(raw, out var id))
+        {
+            throw new FormatException($"The value '{raw}' is not a valid identifier for the '--{name}' option.");
+        }
+
+        return id;
+    }
+
+    private static IReadOnlyCollection<string>? GetOptionalCategories(CommandLineInput input)
+    {
+        if (!input.Options.TryGetValue("category", out var raw)
+            || string.IsNullOrWhiteSpace(raw)
+            || string.Equals(raw, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var categories = raw
+            .Split(',', StringSplitOptions.RemoveEmptyEntries)
+            .Select(category => category.Trim())
+            .Where(category => category.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return categories.Count > 0 ? categories : null;
+    }
+
+    private static void PrintHelp()
+    {
+        Console.WriteLine("Expense Tracker CLI");
+        Console.WriteLine("===================");
+        Console.WriteLine("Manage your personal expenses from the command line.");
+        Console.WriteLine();
+        Console.WriteLine("Usage examples:");
+        Console.WriteLine($"  {ExecutionHint} add --date 2024-05-23 --category Food --amount 12.50 --description \"Lunch\"");
+        Console.WriteLine($"  {ExecutionHint} list --from 2024-05-01 --to 2024-05-31");
+        Console.WriteLine($"  {ExecutionHint} summary --category Food,Travel");
+        Console.WriteLine($"  {ExecutionHint} remove --id <expense-id>");
+        Console.WriteLine();
+        Console.WriteLine("Commands:");
+        Console.WriteLine("  add       Adds a new expense to the tracker.");
+        Console.WriteLine("           Required options: --date yyyy-MM-dd, --category <name>, --amount <value>");
+        Console.WriteLine("  list      Displays expenses. Optional options: --from yyyy-MM-dd, --to yyyy-MM-dd, --category name1,name2");
+        Console.WriteLine("  summary   Provides aggregate information. Shares the optional filters from the list command.");
+        Console.WriteLine("  remove    Deletes an expense using its identifier. Requires --id <guid>.");
+        Console.WriteLine("  help      Displays this screen.");
+    }
+}

--- a/CSharpApp/Program.cs
+++ b/CSharpApp/Program.cs
@@ -306,6 +306,11 @@ internal static class Program
             throw new FormatException($"The value '{raw}' is not a valid identifier for the '--{name}' option.");
         }
 
+        if (id == Guid.Empty)
+        {
+            throw new FormatException($"The value '{raw}' is not a valid identifier for the '--{name}' option.");
+        }
+
         return id;
     }
 

--- a/CSharpApp/README.md
+++ b/CSharpApp/README.md
@@ -20,6 +20,8 @@ dotnet run --project CSharpApp -- <command> [options]
 - `remove` – removes an expense by its identifier (`--id`).
 - `help` – shows the usage information.
 
+The CLI accepts options either as `--name value` or `--name=value`. Unknown options are rejected per command to catch typos early.
+
 ## Storage
 
 At runtime the application looks for the `CSharpApp.csproj` file and stores entries in `data/expenses.json` next to it. When the project file cannot be located (for example, after publishing a self-contained executable) the data file falls back to `<app base>/data/expenses.json`. You can override the location entirely by setting the `EXPENSE_TRACKER_STORAGE` environment variable to an absolute or relative file path before running the program. The generated data file is ignored by Git so that runtime changes do not pollute the repository history.

--- a/CSharpApp/README.md
+++ b/CSharpApp/README.md
@@ -1,0 +1,25 @@
+# Expense Tracker CLI
+
+A lightweight command-line application for recording and analysing personal expenses. By default, data is persisted as JSON inside the `CSharpApp/data` folder (relative to the project file). The project targets .NET 8 and does not require any external dependencies.
+
+## Building and running
+
+```bash
+# Build the project (requires the .NET SDK to be installed)
+dotnet build CSharpApp/CSharpApp.csproj
+
+# Run a command (note the `--` to separate CLI options from `dotnet`)
+dotnet run --project CSharpApp -- <command> [options]
+```
+
+## Available commands
+
+- `add` – records a new expense (requires `--date`, `--category`, and `--amount`).
+- `list` – displays the recorded expenses and accepts filters such as `--from`, `--to`, and `--category`.
+- `summary` – produces aggregate information (total, average, and per-category totals).
+- `remove` – removes an expense by its identifier (`--id`).
+- `help` – shows the usage information.
+
+## Storage
+
+At runtime the application looks for the `CSharpApp.csproj` file and stores entries in `data/expenses.json` next to it. When the project file cannot be located (for example, after publishing a self-contained executable) the data file falls back to `<app base>/data/expenses.json`. You can override the location entirely by setting the `EXPENSE_TRACKER_STORAGE` environment variable to an absolute or relative file path before running the program. The generated data file is ignored by Git so that runtime changes do not pollute the repository history.

--- a/CSharpApp/Services/ExpenseRepository.cs
+++ b/CSharpApp/Services/ExpenseRepository.cs
@@ -1,0 +1,122 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using CSharpApp.Models;
+
+namespace CSharpApp.Services;
+
+/// <summary>
+/// Provides a simple JSON based persistence layer for <see cref="Expense"/> entities.
+/// </summary>
+public sealed class ExpenseRepository
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly object _syncRoot = new();
+    private readonly string _storagePath;
+
+    public ExpenseRepository(string storagePath)
+    {
+        if (string.IsNullOrWhiteSpace(storagePath))
+        {
+            throw new ArgumentException("The storage path cannot be empty.", nameof(storagePath));
+        }
+
+        _storagePath = storagePath;
+        var directory = Path.GetDirectoryName(storagePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+    }
+
+    /// <summary>
+    /// Retrieves all expenses from the storage.
+    /// </summary>
+    public List<Expense> Load()
+    {
+        lock (_syncRoot)
+        {
+            try
+            {
+                if (!File.Exists(_storagePath))
+                {
+                    return new List<Expense>();
+                }
+
+                var json = File.ReadAllText(_storagePath);
+                if (string.IsNullOrWhiteSpace(json))
+                {
+                    return new List<Expense>();
+                }
+
+                var expenses = JsonSerializer.Deserialize<List<Expense?>>(json, SerializerOptions) ?? new List<Expense?>();
+                return expenses
+                    .Where(expense => expense is not null)
+                    .Select(expense => Sanitize(expense!))
+                    .ToList();
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidOperationException($"The storage file '{_storagePath}' does not contain valid JSON data.", ex);
+            }
+            catch (IOException ex)
+            {
+                throw new InvalidOperationException($"Unable to read the storage file '{_storagePath}'.", ex);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Persists the supplied expense collection to storage.
+    /// </summary>
+    public void Save(IEnumerable<Expense> expenses)
+    {
+        if (expenses is null)
+        {
+            throw new ArgumentNullException(nameof(expenses));
+        }
+
+        var payload = expenses
+            .Where(expense => expense is not null)
+            .Select(expense => Sanitize(expense))
+            .ToList();
+
+        lock (_syncRoot)
+        {
+            try
+            {
+                var json = JsonSerializer.Serialize(payload, SerializerOptions);
+                File.WriteAllText(_storagePath, json);
+            }
+            catch (IOException ex)
+            {
+                throw new InvalidOperationException($"Unable to write to the storage file '{_storagePath}'.", ex);
+            }
+        }
+    }
+
+    private static Expense Sanitize(Expense expense)
+    {
+        if (expense is null)
+        {
+            throw new ArgumentNullException(nameof(expense));
+        }
+
+        var clone = expense.Clone();
+        if (clone.Id == Guid.Empty)
+        {
+            clone.Id = Guid.NewGuid();
+        }
+
+        clone.Category = (clone.Category ?? string.Empty).Trim();
+        clone.Description = (clone.Description ?? string.Empty).Trim();
+        clone.Date = clone.Date == default ? DateTime.Today : clone.Date.Date;
+        clone.Amount = decimal.Round(clone.Amount, 2, MidpointRounding.AwayFromZero);
+        return clone;
+    }
+}

--- a/CSharpApp/Services/ExpenseService.cs
+++ b/CSharpApp/Services/ExpenseService.cs
@@ -94,6 +94,11 @@ public sealed class ExpenseService
     /// </summary>
     public bool RemoveExpense(Guid id)
     {
+        if (id == Guid.Empty)
+        {
+            throw new ArgumentException("The expense identifier cannot be empty.", nameof(id));
+        }
+
         var expenses = _repository.Load();
         var removed = expenses.RemoveAll(expense => expense.Id == id) > 0;
         if (removed)

--- a/CSharpApp/Services/ExpenseService.cs
+++ b/CSharpApp/Services/ExpenseService.cs
@@ -112,6 +112,11 @@ public sealed class ExpenseService
         DateTime? to = null,
         IReadOnlyCollection<string>? categories = null)
     {
+        if (from.HasValue && to.HasValue && from.Value.Date > to.Value.Date)
+        {
+            throw new ArgumentException("The 'from' date cannot be later than the 'to' date.");
+        }
+
         var filtered = FilterExpenses(_repository.Load(), from, to, categories);
         var total = filtered.Sum(expense => expense.Amount);
         var count = filtered.Count;

--- a/CSharpApp/Services/ExpenseService.cs
+++ b/CSharpApp/Services/ExpenseService.cs
@@ -1,0 +1,170 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using CSharpApp.Models;
+
+namespace CSharpApp.Services;
+
+/// <summary>
+/// Implements the core business rules for managing expenses.
+/// </summary>
+public sealed class ExpenseService
+{
+    private readonly ExpenseRepository _repository;
+
+    public ExpenseService(ExpenseRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    /// <summary>
+    /// Adds a new expense entry to the storage.
+    /// </summary>
+    public Expense AddExpense(DateTime date, string category, string description, decimal amount)
+    {
+        if (date == default)
+        {
+            throw new ArgumentException("The expense date must be provided.", nameof(date));
+        }
+
+        if (category is null)
+        {
+            throw new ArgumentNullException(nameof(category));
+        }
+
+        category = category.Trim();
+        if (category.Length == 0)
+        {
+            throw new ArgumentException("The expense category cannot be empty.", nameof(category));
+        }
+
+        if (category.Length > 64)
+        {
+            throw new ArgumentException("The expense category cannot exceed 64 characters.", nameof(category));
+        }
+
+        description = (description ?? string.Empty).Trim();
+        if (description.Length > 512)
+        {
+            throw new ArgumentException("The expense description cannot exceed 512 characters.", nameof(description));
+        }
+
+        if (amount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(amount), amount, "The expense amount must be greater than zero.");
+        }
+
+        amount = decimal.Round(amount, 2, MidpointRounding.AwayFromZero);
+
+        var expenses = _repository.Load();
+        var expense = new Expense
+        {
+            Id = Guid.NewGuid(),
+            Date = date.Date,
+            Category = category,
+            Description = description,
+            Amount = amount
+        };
+
+        expenses.Add(expense);
+        _repository.Save(expenses);
+
+        return expense.Clone();
+    }
+
+    /// <summary>
+    /// Retrieves all expenses that match the supplied filters.
+    /// </summary>
+    public IReadOnlyList<Expense> ListExpenses(
+        DateTime? from = null,
+        DateTime? to = null,
+        IReadOnlyCollection<string>? categories = null)
+    {
+        if (from.HasValue && to.HasValue && from.Value.Date > to.Value.Date)
+        {
+            throw new ArgumentException("The 'from' date cannot be later than the 'to' date.");
+        }
+
+        var expenses = _repository.Load();
+        return FilterExpenses(expenses, from, to, categories);
+    }
+
+    /// <summary>
+    /// Removes the expense with the specified identifier from storage.
+    /// </summary>
+    public bool RemoveExpense(Guid id)
+    {
+        var expenses = _repository.Load();
+        var removed = expenses.RemoveAll(expense => expense.Id == id) > 0;
+        if (removed)
+        {
+            _repository.Save(expenses);
+        }
+
+        return removed;
+    }
+
+    /// <summary>
+    /// Computes aggregate information for the stored expenses.
+    /// </summary>
+    public BudgetSummary GetSummary(
+        DateTime? from = null,
+        DateTime? to = null,
+        IReadOnlyCollection<string>? categories = null)
+    {
+        var filtered = FilterExpenses(_repository.Load(), from, to, categories);
+        var total = filtered.Sum(expense => expense.Amount);
+        var count = filtered.Count;
+        var average = count > 0 ? total / count : 0m;
+        var largest = filtered.Count > 0 ? filtered.MaxBy(expense => expense.Amount)?.Clone() : null;
+
+        var categoryTotals = filtered
+            .GroupBy(expense => expense.Category, StringComparer.OrdinalIgnoreCase)
+            .Select(group =>
+            {
+                var representative = group.OrderBy(expense => expense.Category, StringComparer.Ordinal).First();
+                return new CategoryTotal(representative.Category, group.Sum(expense => expense.Amount));
+            })
+            .OrderBy(totalByCategory => totalByCategory.Category, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        return new BudgetSummary(total, average, largest, new ReadOnlyCollection<CategoryTotal>(categoryTotals), count);
+    }
+
+    private static List<Expense> FilterExpenses(
+        List<Expense> source,
+        DateTime? from,
+        DateTime? to,
+        IReadOnlyCollection<string>? categories)
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        IEnumerable<Expense> query = source.Select(expense => expense.Clone());
+
+        if (from.HasValue)
+        {
+            var fromDate = from.Value.Date;
+            query = query.Where(expense => expense.Date >= fromDate);
+        }
+
+        if (to.HasValue)
+        {
+            var toDate = to.Value.Date;
+            query = query.Where(expense => expense.Date <= toDate);
+        }
+
+        if (categories is { Count: > 0 })
+        {
+            var categorySet = new HashSet<string>(categories, StringComparer.OrdinalIgnoreCase);
+            query = query.Where(expense => categorySet.Contains(expense.Category));
+        }
+
+        return query
+            .OrderBy(expense => expense.Date)
+            .ThenBy(expense => expense.Category, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(expense => expense.Description, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+}

--- a/CSharpApp/Services/ExpenseService.cs
+++ b/CSharpApp/Services/ExpenseService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using CSharpApp.Models;
 
 namespace CSharpApp.Services;

--- a/CSharpApp/Utilities/CommandLineParser.cs
+++ b/CSharpApp/Utilities/CommandLineParser.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+
+namespace CSharpApp.Utilities;
+
+/// <summary>
+/// Lightweight parser that converts CLI arguments into a command name and option dictionary.
+/// </summary>
+public static class CommandLineParser
+{
+    public static CommandLineInput Parse(string[] args)
+    {
+        if (args is null)
+        {
+            throw new ArgumentNullException(nameof(args));
+        }
+
+        if (args.Length == 0)
+        {
+            return new CommandLineInput("help", new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+        }
+
+        var command = (args[0] ?? string.Empty).Trim();
+        if (command.Length == 0)
+        {
+            command = "help";
+        }
+
+        var options = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        for (var index = 1; index < args.Length; index++)
+        {
+            var token = args[index] ?? string.Empty;
+            if (!token.StartsWith("--", StringComparison.Ordinal))
+            {
+                throw new ArgumentException($"Unexpected token '{token}'. Options must start with \"--\".");
+            }
+
+            var key = token[2..];
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                throw new ArgumentException("Option names cannot be empty.");
+            }
+
+            if (options.ContainsKey(key))
+            {
+                throw new ArgumentException($"The option '--{key}' was specified more than once.");
+            }
+
+            string value;
+            if (index + 1 < args.Length && !args[index + 1].StartsWith("--", StringComparison.Ordinal))
+            {
+                value = args[++index];
+            }
+            else
+            {
+                value = "true";
+            }
+
+            options[key] = value;
+        }
+
+        return new CommandLineInput(command, options);
+    }
+}
+
+public sealed record CommandLineInput(string Command, IReadOnlyDictionary<string, string> Options);

--- a/CSharpApp/Utilities/CommandLineParser.cs
+++ b/CSharpApp/Utilities/CommandLineParser.cs
@@ -34,7 +34,21 @@ public static class CommandLineParser
                 throw new ArgumentException($"Unexpected token '{token}'. Options must start with \"--\".");
             }
 
-            var key = token[2..];
+            var optionToken = token[2..];
+            var equalsIndex = optionToken.IndexOf('=');
+
+            string key;
+            string? inlineValue = null;
+            if (equalsIndex >= 0)
+            {
+                key = optionToken[..equalsIndex];
+                inlineValue = optionToken[(equalsIndex + 1)..];
+            }
+            else
+            {
+                key = optionToken;
+            }
+
             if (string.IsNullOrWhiteSpace(key))
             {
                 throw new ArgumentException("Option names cannot be empty.");
@@ -46,7 +60,11 @@ public static class CommandLineParser
             }
 
             string value;
-            if (index + 1 < args.Length && !args[index + 1].StartsWith("--", StringComparison.Ordinal))
+            if (inlineValue is not null)
+            {
+                value = inlineValue;
+            }
+            else if (index + 1 < args.Length && !args[index + 1].StartsWith("--", StringComparison.Ordinal))
             {
                 value = args[++index];
             }

--- a/CSharpApp/Utilities/TableFormatter.cs
+++ b/CSharpApp/Utilities/TableFormatter.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace CSharpApp.Utilities;
+
+/// <summary>
+/// Provides helper methods for rendering collections as text tables.
+/// </summary>
+public static class TableFormatter
+{
+    public static string Format(IEnumerable<IReadOnlyList<string>> rows)
+    {
+        if (rows is null)
+        {
+            throw new ArgumentNullException(nameof(rows));
+        }
+
+        var normalizedRows = rows
+            .Select(row => row?.Select(cell => cell ?? string.Empty).ToArray() ?? Array.Empty<string>())
+            .ToList();
+
+        if (normalizedRows.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var columnCount = normalizedRows.Max(row => row.Length);
+        var widths = new int[columnCount];
+
+        foreach (var row in normalizedRows)
+        {
+            for (var column = 0; column < row.Length; column++)
+            {
+                widths[column] = Math.Max(widths[column], row[column].Length);
+            }
+        }
+
+        var builder = new StringBuilder();
+        for (var index = 0; index < normalizedRows.Count; index++)
+        {
+            builder.AppendLine(FormatRow(normalizedRows[index], widths));
+
+            if (index == 0)
+            {
+                builder.AppendLine(FormatDivider(widths));
+            }
+        }
+
+        return builder.ToString().TrimEnd();
+    }
+
+    public static IReadOnlyList<string> Row(params string[] values)
+    {
+        return values ?? Array.Empty<string>();
+    }
+
+    private static string FormatRow(IReadOnlyList<string> row, IReadOnlyList<int> widths)
+    {
+        var cells = new string[widths.Count];
+        for (var column = 0; column < widths.Count; column++)
+        {
+            var value = column < row.Count ? row[column] : string.Empty;
+            cells[column] = (value ?? string.Empty).PadRight(widths[column]);
+        }
+
+        return string.Join("  ", cells);
+    }
+
+    private static string FormatDivider(IReadOnlyList<int> widths)
+    {
+        var cells = new string[widths.Count];
+        for (var column = 0; column < widths.Count; column++)
+        {
+            var width = Math.Max(1, widths[column]);
+            cells[column] = new string('-', width);
+        }
+
+        return string.Join("  ", cells);
+    }
+}


### PR DESCRIPTION
## Summary
- resolve the default JSON storage path relative to the project file and allow overriding via an environment variable
- document how the storage path is chosen and how to override it in the README

## Testing
- dotnet build CSharpApp/CSharpApp.csproj *(fails: dotnet CLI not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa5199b0a8832e877f32cb3fdc794d